### PR TITLE
Harden initial query schema

### DIFF
--- a/core/app/graphql/maeku/query_schema.rb
+++ b/core/app/graphql/maeku/query_schema.rb
@@ -3,20 +3,30 @@ module Maeku
     graphql_name "Query"
     description "The query root for this API."
 
+    field :all_authors, [Types::AuthorType], null: true do
+      description "Returns information about all authors. Note that the " \
+        "class is not provided by Maeku, so author fields differ from "   \
+        "application to application."
+    end
+
     field :all_entries, [Types::EntryType], null: true do
       description "Returns information about all entry records."
       argument :limit, Int, default_value: 30, required: false
     end
 
     field :current_author, Types::AuthorType, null: true do
-      description "Returns data about the current user. Note that the " \
-      "class is not provided by Maeku, so author fields differ from "   \
+      description "Returns data about the current user. Note that the "   \
+      "class is not provided by Maeku, so author fields differ from "     \
       "application to application."
     end
 
-    field :my_entries, [Types::EntryType], null: true do
+    field :current_author_entries, [Types::EntryType], null: true do
       description "Returns entries posted by the current author."
       argument :limit, Int, default_value: 30, required: false
+    end
+
+    def all_authors
+      Maeku.author_class.all
     end
 
     def all_entries(args)
@@ -27,7 +37,7 @@ module Maeku
       context[:current_author]
     end
 
-    def my_entries(args)
+    def current_author_entries(args)
       Entry.entries_for(context[:current_author]).limit(args[:limit]).order(updated_at: :desc)
     end
   end

--- a/core/app/graphql/maeku/types/author_type.rb
+++ b/core/app/graphql/maeku/types/author_type.rb
@@ -2,12 +2,18 @@ module Maeku
   class Types::AuthorType < Types::BaseType
     description "Type for the application-provided #{Maeku.author_class.name} class."
 
+    field :entries, [Types::EntryType], null: true
+
     Maeku.author_class.columns.each do |column|
       ignored_column_types = [:date, :datetime, :time]
       unless ignored_column_types.include? column.type
         type = const_get(column.type.to_s.capitalize)
         field column.name.to_sym, type, null: true if column.name !~ /password/
       end
+    end
+
+    def entries
+      Entry.where(author_id: id)
     end
 
   end

--- a/core/app/graphql/maeku/types/entry_type.rb
+++ b/core/app/graphql/maeku/types/entry_type.rb
@@ -1,7 +1,7 @@
 module Maeku
   class Types::EntryType < Types::BaseType
     field :id, ID, null: false
-    field :author, AuthorType, null: false
+    field :author, Types::AuthorType, null: false
     field :type, String, null: true
     field :content, String, null: true
     # todo ~ what's the best way to include entry attachments in api queries?


### PR DESCRIPTION
There is now a clearer pattern for our root queries:

-`all[records]`
- `currentAuthor[records]`

So for now, we have four root queries:

- `allAuthors`
- `allEntries`
- `currentAuthor`
- `currentAuthorEntries`

Also, you can get a list of entries by an author when you when an `allAuthors` or `currentAuthor` query!